### PR TITLE
Fix portability of file paths

### DIFF
--- a/Classes/Board.py
+++ b/Classes/Board.py
@@ -1,3 +1,4 @@
+import os.path
 import pygame
 import Classes.Wall as w
 import Classes.Brick as b
@@ -85,8 +86,8 @@ class Board(object):
 
     def buttons(self):
         # Create buttons
-        self.exitBtn = btn.Button("Pictures\exit.png", (200, 600))
-        self.menuBtn = btn.Button("Pictures\menu.png", (400, 600))
+        self.exitBtn = btn.Button(os.path.join("Pictures", "exit.png"), (200, 600))
+        self.menuBtn = btn.Button(os.path.join("Pictures", "menu.png"), (400, 600))
 
     def show_board(self):
         for i in range(len(self.game)):

--- a/Classes/Screen_codes/Game_screen.py
+++ b/Classes/Screen_codes/Game_screen.py
@@ -1,3 +1,4 @@
+import os.path
 from PyQt5.QtWidgets import QDialog
 from PyQt5.QtCore import pyqtSlot
 from PyQt5 import uic
@@ -6,7 +7,7 @@ from Classes.Screen_codes.Options_screen import Options
 from Classes.Screen_codes.Ranking_screen import Ranking
 
 
-qtCreatorFile = "Classes\GUI\game.ui"
+qtCreatorFile = os.path.join("Classes", "GUI", "game.ui")
 Ui_Dialog, QtBaseClass = uic.loadUiType(qtCreatorFile)
 
 

--- a/Classes/Screen_codes/Login_screen.py
+++ b/Classes/Screen_codes/Login_screen.py
@@ -1,3 +1,4 @@
+import os.path
 from PyQt5.QtWidgets import QMainWindow
 from PyQt5.QtCore import pyqtSlot
 from PyQt5 import uic
@@ -9,7 +10,7 @@ import http.client
 import hashlib
 import sys
 
-qtCreatorFile = "Classes\GUI\login.ui"
+qtCreatorFile = os.path.join("Classes", "GUI", "login.ui")
 Ui_MainWindow, QtBaseClass = uic.loadUiType(qtCreatorFile)
 
 


### PR DESCRIPTION
Dotychczasowe rozwiązanie było kompatybilne jedynie z Windowsem, `os.path.join` natomiast z założenia tworzy ścieżki z wykorzystaniem separatorów odpowiednich dla systemu, na jakim uruchomiona jest aplikacja.